### PR TITLE
Change from_buffer_copy to from_buffer

### DIFF
--- a/sim_info_sync.py
+++ b/sim_info_sync.py
@@ -121,10 +121,10 @@ class SimInfoSync():
         check_counter = 0        # counter for data version update check
 
         while self.data_updating:
-            data_scor = rF2data.rF2Scoring.from_buffer_copy(self._rf2_scor)
-            data_tele = rF2data.rF2Telemetry.from_buffer_copy(self._rf2_tele)
-            self.LastExt = rF2data.rF2Extended.from_buffer_copy(self._rf2_ext)
-            self.LastFfb = rF2data.rF2ForceFeedback.from_buffer_copy(self._rf2_ffb)
+            data_scor = rF2data.rF2Scoring.from_buffer(self._rf2_scor)
+            data_tele = rF2data.rF2Telemetry.from_buffer(self._rf2_tele)
+            self.LastExt = rF2data.rF2Extended.from_buffer(self._rf2_ext)
+            self.LastFfb = rF2data.rF2ForceFeedback.from_buffer(self._rf2_ffb)
 
             # Update player index
             if not data_freezed:


### PR DESCRIPTION
I've changed `from_buffer_copy` to `from_buffer` and it performs much better since it doesn't have to copy the buffers.

This change requires #3 to work on Linux. I guess it should work on Windows too but someone should test it.